### PR TITLE
删除package.json中的bin字段

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.3",
   "description": "EFE-Style Node.js module generator for yeoman",
   "main": "app/index.js",
-  "bin": {
-    "generator-efe-module": "./bin/generator-efe-module"
-  },
   "dependencies": {
     "chalk": "^1.0.0",
     "github": "^0.2.4",


### PR DESCRIPTION
推测 npm istall -g 报错是因此而起。